### PR TITLE
Allow user to override some vcf2maf/maf2maf args

### DIFF
--- a/bin/cmo_maf2maf
+++ b/bin/cmo_maf2maf
@@ -37,9 +37,13 @@ if __name__ =='__main__':
     args_dict, defaults_dict = parse_script_help(script_path)
 
     # Let's change some of the defaults based on data in the CMO JSON
+    defaults_dict['--vep-path'] = cmo.util.programs['vep'][options.vep_release]
+    defaults_dict['--vep-data'] = cmo.util.genomes[options.ncbi_build]['vep_cache']
+    defaults_dict['--ref-fasta'] = cmo.util.genomes[options.ncbi_build]['fasta']
     defaults_dict['--custom-enst'] = cmo.util.programs['vcf2maf'][options.version] + "data/isoform_overrides_at_mskcc"
-    defaults_dict['--filter-vcf'] = cmo.util.genomes['GRCh37']['exac']
+    defaults_dict['--filter-vcf'] = cmo.util.genomes[options.ncbi_build]['exac']
     defaults_dict['--retain-cols'] = 'Center,Verification_Status,Validation_Status,Mutation_Status,Sequencing_Phase,Sequence_Source,Validation_Method,Score,BAM_file,Sequencer,Tumor_Sample_UUID,Matched_Norm_Sample_UUID,Caller'
+    # This is just for display in --help; we'll create it later below
     tmp_root = "/scratch/<username>/..."
     defaults_dict['--tmp-dir'] = tmp_root
 
@@ -47,7 +51,7 @@ if __name__ =='__main__':
     parser = argparse.ArgumentParser(parents = [preparser], add_help=True, formatter_class=SortingHelpFormatter)
     for arg, description in args_dict.items():
         # Hide a few arguments from the user, because we'll determine them ourselves
-        if arg in ["--help","--man","--vep-path","--vep-data","--ref-fasta","--species","--ncbi-build","--cache-version"]:
+        if arg in ["--help","--man","--species","--ncbi-build","--cache-version"]:
             continue
         if arg in defaults_dict and arg not in ["--output-maf"]:
             parser.add_argument(arg, action="store", metavar='', help=description, default=defaults_dict[arg])
@@ -73,13 +77,16 @@ if __name__ =='__main__':
                 "fill up and interrupt your colleagues' work. If you're working with giant " +
                 "files, then please define your own --tmp-dir.\n" )
 
-    # Locate VEP and it's cache, the reference FASTA, and the VCF used for filtering
-    args_dict['vep_path'] = cmo.util.programs['vep'][args.vep_release]
-    args_dict['vep_data'] = cmo.util.genomes[args.ncbi_build]['vep_cache']
-    args_dict['ref_fasta'] = cmo.util.genomes[args.ncbi_build]['fasta']
-    try:
+    # If user defined non-default VEP release or NCBI build, then fetch new paths from CMO JSON
+    if options.vep_release is not args.vep_release:
+        args_dict['vep_path'] = cmo.util.programs['vep'][args.vep_release]
+    if options.ncbi_build is not args.ncbi_build:
+        args_dict['vep_data'] = cmo.util.genomes[args.ncbi_build]['vep_cache']
+        args_dict['ref_fasta'] = cmo.util.genomes[args.ncbi_build]['fasta']
         args_dict['filter_vcf'] = cmo.util.genomes[args.ncbi_build]['exac']
-    except:
+
+    # We should not use the --filter-vcf argument unless we have one for this specific genome
+    if not args_dict['filter_vcf']:
         del args_dict['filter_vcf']
 
     # Remove arguments that the actual wrapped tool won't recognize

--- a/bin/cmo_vcf2maf
+++ b/bin/cmo_vcf2maf
@@ -37,11 +37,15 @@ if __name__ =='__main__':
     args_dict, defaults_dict = parse_script_help(script_path)
 
     # Let's change some of the defaults based on data in the CMO JSON
+    defaults_dict['--vep-path'] = cmo.util.programs['vep'][options.vep_release]
+    defaults_dict['--vep-data'] = cmo.util.genomes[options.ncbi_build]['vep_cache']
+    defaults_dict['--ref-fasta'] = cmo.util.genomes[options.ncbi_build]['fasta']
     defaults_dict['--custom-enst'] = cmo.util.programs['vcf2maf'][options.version] + "data/isoform_overrides_at_mskcc"
-    defaults_dict['--filter-vcf'] = cmo.util.genomes['GRCh37']['exac']
+    defaults_dict['--filter-vcf'] = cmo.util.genomes[options.ncbi_build]['exac']
     defaults_dict['--maf-center'] = 'mskcc.org'
     defaults_dict['--vcf-tumor-id'] = defaults_dict['--tumor-id']
     defaults_dict['--vcf-normal-id'] = defaults_dict['--normal-id']
+    # This is just for display in --help; we'll create it later below
     tmp_root = "/scratch/<username>/..."
     defaults_dict['--tmp-dir'] = tmp_root
 
@@ -49,7 +53,7 @@ if __name__ =='__main__':
     parser = argparse.ArgumentParser(parents = [preparser], add_help=True, formatter_class=SortingHelpFormatter)
     for arg, description in args_dict.items():
         # Hide a few arguments from the user, because we'll determine them ourselves
-        if arg in ["--help","--man","--vep-path","--vep-data","--ref-fasta","--species","--ncbi-build","--cache-version"]:
+        if arg in ["--help","--man","--species","--ncbi-build","--cache-version"]:
             continue
         if arg in defaults_dict and arg not in ["--output-maf"]:
             parser.add_argument(arg, action="store", metavar='', help=description, default=defaults_dict[arg])
@@ -75,13 +79,16 @@ if __name__ =='__main__':
                 "fill up and interrupt your colleagues' work. If you're working with giant " +
                 "files, then please define your own --tmp-dir.\n" )
 
-    # Locate VEP and it's cache, the reference FASTA, and the VCF used for filtering
-    args_dict['vep_path'] = cmo.util.programs['vep'][args.vep_release]
-    args_dict['vep_data'] = cmo.util.genomes[args.ncbi_build]['vep_cache']
-    args_dict['ref_fasta'] = cmo.util.genomes[args.ncbi_build]['fasta']
-    try:
+    # If user defined non-default VEP release or NCBI build, then fetch new paths from CMO JSON
+    if options.vep_release is not args.vep_release:
+        args_dict['vep_path'] = cmo.util.programs['vep'][args.vep_release]
+    if options.ncbi_build is not args.ncbi_build:
+        args_dict['vep_data'] = cmo.util.genomes[args.ncbi_build]['vep_cache']
+        args_dict['ref_fasta'] = cmo.util.genomes[args.ncbi_build]['fasta']
         args_dict['filter_vcf'] = cmo.util.genomes[args.ncbi_build]['exac']
-    except:
+
+    # We should not use the --filter-vcf argument unless we have one for this specific genome
+    if not args_dict['filter_vcf']:
         del args_dict['filter_vcf']
 
     # Remove arguments that the actual wrapped tool won't recognize


### PR DESCRIPTION
This will require a few changes in the `cmo_resources` JSON. Specifically, you need to add a key `exac` with an empty value to GRCh38 and GRCm38. Within a month, I'll have a filter VCF that should work with GRCm38, based on Sanger's MGP. Then I'll update the JSON with the path to that. For filter VCF for GRCh38, I got no ETA. Depends on the ExAC/gnomAD folks.